### PR TITLE
Update get_currencies query params. Fix bug with transparency.

### DIFF
--- a/nomics/api/currencies.py
+++ b/nomics/api/currencies.py
@@ -3,21 +3,44 @@ import requests
 from .api import API
 
 class Currencies(API):
-    def get_currencies(self, ids, interval = None, convert = None, include_transparency = False):
+    def get_currencies(self, ids, interval = None, convert = None, status = None, filter = None, sort = None,
+                       include_transparency = False, per_page = None, page = None):
         '''
         Returns price, volume, market cap, and rank for all currencies
 
-        :param  str   ids:                      Comma separated list of Nomics Currency IDs 
+        :param  str   ids:                      Comma separated list of Nomics Currency IDs
                                                 to filter result rows.
 
-        :param  str   interval:                 Comma separated time interval of the ticker(s). 
+        :param  str   interval:                 Comma separated time interval of the ticker(s).
                                                 Default is 1d,7d,30d,365d,ytd
 
-        :param  str     convert:                Currency to quote ticker price, market cap, and volume values. 
-                                                May be a Fiat Currency or Cryptocurrency. 
-                                                Default is USD.     
-        :param  bool    include-transparency:   Whether to include Transparent Volume information for currencies. 
+        :param  str   convert:                  Currency to quote ticker price, market cap, and volume values.
+                                                May be a Fiat Currency or Cryptocurrency.
+                                                Default is USD.
+
+        :param  str   status:                   Status by which to filter currencies. If not provided, all currencies
+                                                are shown.
+                                                Available options: "active" "inactive" "dead"
+
+        :param  str   filter:                   Further filter the set of currencies. The new filter returns currencies
+                                                that have recently been priced by Nomics and any returns currencies
+                                                regardless of their state. The any filer may be used to retrieve
+                                                new-but-stale currencies that are listed under new, but are no longer
+                                                active.
+                                                Available options: "any" "new"
+
+        :param  str   sort:                     How to sort the returned currencies. rank sorts by rank ascending and
+                                                first_priced_at sorts by when each currency was first priced by Nomics
+                                                descending.
+                                                Available options: "rank" "first_priced_at"
+
+        :param  bool  include-transparency:     Whether to include Transparent Volume information for currencies.
                                                 Default is false. Only available to paid API plans
+
+        :param  int    per_page:                The maximum number of items to return per paginated response
+
+        :param  int    page:                    Which page of items to get. Only applicable when per-page is also
+                                                supplied.
         '''
 
         if type(ids) != str:
@@ -31,7 +54,12 @@ class Currencies(API):
             'ids': ids,
             'interval': interval,
             'convert': convert,
-            'include-transparency': include_transparency
+            'status': status,
+            'filter': filter,
+            'sort': sort,
+            'include-transparency': include_transparency or None,
+            'per-page': per_page,
+            'page': page
         }
 
         resp = requests.get(url, params = params)
@@ -79,7 +107,7 @@ class Currencies(API):
             'start': start,
             'end': end
         }
-        
+
         resp = requests.get(url, params = params)
 
         if resp.status_code == 200:


### PR DESCRIPTION
@TaylorFacen 👋 

This PR:
 - Adds missing query params for `get_currencies` as described in [the doco](https://nomics.com/docs/#operation/getCurrenciesTicker):
 - Fixes a bug with `include_transparency`, where even an argument of `False` is rejected by Nomics for a free plan with the following error:
    > Your plan does not allow you to access transparency information. See https://p.nomics.com/pricing for more information.

 In this case, Nomics expects no argument be provided at all.